### PR TITLE
Feat/milis: função que calcula milissegundos

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -7,4 +7,10 @@
 // value precisa ser < 100
 void uitoascii(uint8_t value, char *buffer);
 
+// Configuração de timers
+void timerConfig();
+
+// Retorna milissegundos que passaram
+uint32_t milis(void); 
+
 #endif // UTILS_H_INCLUDED

--- a/src/main.c
+++ b/src/main.c
@@ -20,7 +20,7 @@ int main(void)
   
   while(1)                                  // continuous loop
   {
-    if (ms - milis() >= 1000) {             // 1 segundo se passou
+    if (milis() - ms >= 1000) {             // 1 segundo se passou
       P1OUT ^= BIT0;                        // XOR P1.0
       ms = milis();                         // Atualiza milis
     }

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,6 @@
 #include <msp430.h>
 #include "lcd.h"
+#include "utils.h"
 
 int main(void)
 {
@@ -12,9 +13,13 @@ int main(void)
   lcdWake();
   lcdWrite("Hello World!");
 
+  uint32_t ms = milis(); 
+
   while(1)                                  // continuous loop
   {
-    P1OUT ^= BIT0;                          // XOR P1.0
-    for(i=50000;i>0;i--);                   // Delay
+    if (ms - milis() >= 1000) {             // 1 segundo se passou
+      P1OUT ^= BIT0;                        // XOR P1.0
+      ms = milis();                         // Atualiza milis
+    }
   }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -13,8 +13,11 @@ int main(void)
   lcdWake();
   lcdWrite("Hello World!");
 
-  uint32_t ms = milis(); 
+  timerConfig();
+  __enable_interrupt();
 
+  uint32_t ms = milis(); 
+  
   while(1)                                  // continuous loop
   {
     if (ms - milis() >= 1000) {             // 1 segundo se passou

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,4 +1,5 @@
 #include "utils.h"
+#include <msp430.h>
 
 static volatile uint32_t ms = 0;
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,5 +1,11 @@
 #include "utils.h"
 
+static volatile uint32_t ms = 0;
+
+uint32_t milis(void) {
+  return ms;
+}
+
 void uitoascii(uint8_t value, char *buffer) {
   if (value == 0) {
     buffer[0] = '0';
@@ -22,4 +28,15 @@ void uitoascii(uint8_t value, char *buffer) {
   }
 
   buffer[j] = '\0';
+}
+
+void timerConfig(void) {
+  TA0CCTL0 |= CCIE;
+  TA0CTL = TASSEL__SMCLK | MC__UP | TACLR; // @ 1Mhz
+  TA0CCR0 = 1000; // 1 ms 
+}
+
+#pragma vector = TIMER0_A0_VECTOR
+__interrupt void Timer0_A0_ISR(void) {
+  ms++;
 }


### PR DESCRIPTION
Função que retorna `uint_32t` representando a quantidade de milissegundos que se passaram desde o início da contagem. Retorna uma variável atualizada pelo Timer A0.

`main.c`: LED 1.0 deve piscar a cada 1 segundo.