### PR TITLE
Corrigir FSM e entrada

### DIFF
--- a/src/fsm.c
+++ b/src/fsm.c
@@ -9,7 +9,7 @@ u8 access_attempts = 0;
 void updateState(void)
 {
     // Para detectar transições de estado
-    static State previous_state = SLEEPING;
+    static State previous_state = BLOCKED;
     static State state = SLEEPING;
 
     u8 entering = previous_state != state;

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -78,8 +78,8 @@ State stateReadingInput(u8 entering)
         volatile u8* input = inputBuffer();
         
         // ==== TODO: checar senha real ====== 
-        if (input[0] == 1 && input[1] == 2 &&
-            input[2] == 1 && input[3] == 2 &&
+        if (input[0] == 1 && input[1] == 1 &&
+            input[2] == 1 && input[3] == 1 &&
             input[4] == 1) {
             // Ir para acesso garantido
             access_attempts = 0;

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -28,8 +28,9 @@ void updateState(void)
             {
                 lcdSleep();
                 led_G_off();
-                led_G_stt_Blink(30);
+                led_R_stt_Blink(500);
             }
+            if (inputLength()) state = READING_INPUT;
             break;
         }
         case (READING_INPUT):

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -82,10 +82,10 @@ State stateReadingInput(u8 entering)
             input[2] == 1 && input[3] == 1 &&
             input[4] == 1) {
             // Ir para acesso garantido
-            access_attempts = 0;
+            clearInput();
             return ACCESS_GRANTED;
         } else {
-            access_attempts++;
+            clearInput();
             return ACCESS_DENIED;
         }
         // ==================================
@@ -97,6 +97,7 @@ State stateAccessGranted(u8 entering)
 {
     if (entering)
     {
+        access_attempts = 0;
         lcdClear();
         lcdWrite("ACESSO LIBERADO!");
         led_G_on();
@@ -117,6 +118,7 @@ State stateAccessDenied(u8 entering)
         lcdWrite("ACESSO NEGADO!");
         led_G_off();
         led_R_stt_Blink(500);
+        access_attempts++;
     }
 
     // Depende de quantas tentativas erradas seguidas
@@ -135,6 +137,7 @@ State stateBlocked(u8 entering)
     static u32 last_time_dec = 0;
     if (entering)
     {
+        access_attempts = 0;
         inputDisable();
         lcdClear();
         led_R_stt_Blink(500);

--- a/src/input.c
+++ b/src/input.c
@@ -72,7 +72,7 @@ u8 inputLength(void)
     return input.length;
 }
 
-#pragma vector = TIMER0_A1_VECTOR
+#pragma vector = TIMER1_A0_VECTOR
 __interrupt void debounce(void) {
     TA1CTL = MC_0;    // Para o timer
 

--- a/src/input.c
+++ b/src/input.c
@@ -26,7 +26,7 @@ void inputInit(void)
 void clearInput(void)
 {
     input.length = 0;
-    input.last_modified = milis();  
+    input.last_modified = milis();
 }
 
 void inputUpdate(void)
@@ -64,7 +64,7 @@ volatile u8* inputBuffer(void)
 
 u8 inputIsActive(void)
 {
-    return !(input.length == 0 && timeout(input.last_modified, 30000));
+    return !(input.length == 0 && timeout(input.last_modified, 3000));
 }
 
 u8 inputLength(void)

--- a/src/led.c
+++ b/src/led.c
@@ -21,11 +21,13 @@ void led_R_on() {
 void led_R_off() {
   blinking &= ~LED_R; // Para de piscar
   P1OUT &= ~LED_R;    // Desliga o LED vermelho
+  led_r_period = 0;
 }
 
 void led_G_on() {
   blinking &= ~LED_G; // Para de piscar
   P4OUT |= LED_G;     // Liga o LED verde
+  led_g_period = 0;
 }
 
 void led_G_off() {
@@ -67,7 +69,7 @@ void led_Blocked() {
 }
 
 void led_R_stt_Blink(u32 period) {
-  led_g_start = milis();  // Pega tempo atual
+  led_r_start = milis();  // Pega tempo atual
   led_r_period = period;  // Seta período de alternar
   blinking |= LED_R;      // Sinaliza blinking
 }


### PR DESCRIPTION
## Corrigido
- Transição para o `SLEEPING` na primeira execução
- Transição do `SLEEPING` para `READING_INPUT` adicionada (corrige #8 )
- Vetor da interrupção do debounce dos botões corrigido para `TIMER1_A0_VECTOR` (corrigindo bug do ISR trap #9 )
- Timeout de entrada vazia corrigido para 3 segundos (3000 ms)
- Corrigido variável de período (para `led_r_period`) em `led_r_stt_blink(u32 period)`