### PR TITLE
Correção de inicialização do LCD

### DIFF
--- a/src/lcd.c
+++ b/src/lcd.c
@@ -26,7 +26,7 @@ void i2cInitMaster(void) {
 }
 
 void lcdInit(void) {
-  uint8_t nibble = 3 << 4; // Colocando no msb
+  uint8_t nibble = 3;
 
   // Iniciando LCD corretamente
   lcdWriteNibble(nibble, 0);
@@ -37,7 +37,7 @@ void lcdInit(void) {
   __delay_cycles(20000);
 
   // Modo 4 bits
-  nibble = 2 << 4;
+  nibble = 2;
   lcdWriteNibble(nibble, 0);
   __delay_cycles(20000);
 
@@ -64,8 +64,8 @@ uint8_t i2cSend(uint8_t slaveAddr, uint8_t data) {
 }
 
 uint8_t lcdWriteNibble(uint8_t nibble, uint8_t isChar) {
-  uint8_t data = (nibble) & 0xF0; // Coloca o nibble em D7–D4
-  data |= LCD_BL;                 // Mantém a luz de fundo ligada
+  uint8_t data = (nibble << 4) & 0xF0;  // Coloca o nibble em D7–D4
+  data |= LCD_BL;                       // Mantém a luz de fundo ligada
 
   if (isChar)
     data |= LCD_RS; // RS = 1 se for caractere
@@ -78,8 +78,8 @@ uint8_t lcdWriteNibble(uint8_t nibble, uint8_t isChar) {
 }
 
 uint8_t lcdWriteByte(uint8_t byte, uint8_t isChar) {
-  uint8_t nack = lcdWriteNibble(byte, isChar); // byte[7:4]
-  nack |= lcdWriteNibble(byte << 4, isChar);   // byte[3:0]
+  uint8_t nack = lcdWriteNibble(byte >> 4, isChar); // byte[7:4]
+  nack |= lcdWriteNibble(byte & 0x0F, isChar);   // byte[3:0]
   return nack;
 }
 

--- a/src/lcd.c
+++ b/src/lcd.c
@@ -26,7 +26,7 @@ void i2cInitMaster(void) {
 }
 
 void lcdInit(void) {
-  uint8_t nibble = 3;
+  uint8_t nibble = 3 << 4; // Colocando no msb
 
   // Iniciando LCD corretamente
   lcdWriteNibble(nibble, 0);
@@ -37,7 +37,7 @@ void lcdInit(void) {
   __delay_cycles(20000);
 
   // Modo 4 bits
-  nibble = 2;
+  nibble = 2 << 4;
   lcdWriteNibble(nibble, 0);
   __delay_cycles(20000);
 


### PR DESCRIPTION
## Mudanças
- Função `lcdWriteNibble` faz o deslocamento para direita do parâmetro nibble, o que antes precisava ser feito fora da função e causava confusão
- Adaptada definição de `lcdWriteByte` para nova definição de `lcdWriteNibble`

## Correção (closes #10 )
- Com a nova definiçao de `lcdWriteNibble`, os nibbles de configuração inicial serão corretamente transmitidos por `lcdInit`