### PR TITLE
Modo de baixo consumo

### DIFF
--- a/src/fsm.c
+++ b/src/fsm.c
@@ -30,6 +30,7 @@ void updateState(void)
                 lcdSleep();
                 led_G_off();
                 led_G_stt_Blink(30);
+                __low_power_mode_3(); // trocar p 0 se bugar
             }
             break;
         }

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -30,8 +30,8 @@ void updateState(void)
                 lcdSleep();
                 led_G_off();
                 led_G_stt_Blink(30);
-                __low_power_mode_3(); // trocar p 0 se bugar
             }
+            __low_power_mode_3(); // trocar p 0 se bugar
             break;
         }
         case (READING_INPUT):

--- a/src/fsm.c
+++ b/src/fsm.c
@@ -2,6 +2,7 @@
 #include "input.h"
 #include "lcd.h"
 #include "led.h"
+#include "uart.h"
 
 u32 last_transition;
 u8 access_attempts = 0;
@@ -99,6 +100,7 @@ State stateAccessGranted(u8 entering)
         lcdClear();
         lcdWrite("ACESSO LIBERADO!");
         led_G_on();
+        uartPrint("ACESSO LIBERADO\n");
     }
 
     if (timeout(last_transition, 3000))
@@ -114,6 +116,7 @@ State stateAccessDenied(u8 entering)
         inputDisable();
         lcdClear();
         lcdWrite("ACESSO NEGADO!");
+        uartPrint("ACESSO NEGADO\n");
         led_G_off();
         led_R_stt_Blink(500);
     }
@@ -139,6 +142,7 @@ State stateBlocked(u8 entering)
         led_R_stt_Blink(500);
         last_time_dec = milis();
         time_remaining = 10;
+        uartPrint("BLOQUEADO APÓS 3 TENTATIVAS\n");
     }
     
     if (timeout(last_time_dec, 1000))

--- a/src/input.c
+++ b/src/input.c
@@ -103,6 +103,7 @@ __interrupt void S1_ISR(void) {
 
     // Timer de debounce
     TA1CTL = TASSEL_2 + MC_1 + TACLR;
+    __low_power_mode_off_on_exit();
   }
 }
 
@@ -113,5 +114,6 @@ __interrupt void S2_ISR(void) {
     P1IFG &= ~BIT1;
 
     TA1CTL = TASSEL_2 + MC_1 + TACLR;
+    __low_power_mode_off_on_exit();
   }
 }

--- a/src/uart.c
+++ b/src/uart.c
@@ -52,4 +52,5 @@ __interrupt void uart_isr()
 	if(c == 0x0D)
 		command_received = 1;
 	
+	__low_power_mode_off_on_exit();
 }


### PR DESCRIPTION
## Mudanças
- O estado de ´SLEEPING´ agora faz o micro. entrar no modo de baixo consumo `_low_power_mode_3()` (pode ser trocado para o 0 caso dar problemas). Ele sai do modo de baixo consumo em caso de interrupção dos botões (para possibilitar transição de estados), e também em caso de interrupção da interface UART (para que o loop principal seja executado até o final e passe pela parte de processar o comando UART). 